### PR TITLE
remove dependency to cmd_lib_core

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,21 @@
-use cmd_lib_core;
-use cmd_lib_macros;
+pub use cmd_lib_core;
+pub use cmd_lib_macros;
 
-pub use cmd_lib_macros::{
-    run_cmd,
-    run_fun,
-};
+#[macro_export]
+macro_rules! run_cmd {
+    ($($cur:tt)*) => {{
+	use $crate::cmd_lib_core;
+	$crate::cmd_lib_macros::run_cmd!($($cur)*)
+    }};
+}
+
+#[macro_export]
+macro_rules! run_fun {
+    ($($cur:tt)*) => {{
+	use $crate::cmd_lib_core;
+	$crate::cmd_lib_macros::run_fun!($($cur)*)
+    }};
+}
 
 pub use cmd_lib_core::{
     run_cmd,


### PR DESCRIPTION
Programs using the cmd_lib crate requires to include the cmd_lib_core as
the macros are procedural macros which do not yet support $crate as for regular
macros (See https://github.com/rust-lang/rust/issues/54363).

This commit re-export the procedural macros as well as core/macro libraries. It
also makes sure that the cmd_lib_core is not required by a depending crate.