### PR TITLE
feat: Add `build-print` feature to enable logging in `build.rs` scripts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,12 @@ log = "0.4.20"
 faccess = "0.2.4"
 os_pipe = "1.1.4"
 env_logger = "0.10.0"
+build-print = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 rayon = "1.8.0"
 clap = { version = "4", features = ["derive"] }
 byte-unit = "4.0.19"
+
+[features]
+build-print = ["dep:build-print"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,8 +376,12 @@ pub use cmd_lib_macros::{
 pub type FunResult = std::io::Result<String>;
 /// Return type for [`run_cmd!()`] macro.
 pub type CmdResult = std::io::Result<()>;
+#[cfg(feature = "build-print")]
+#[doc(hidden)]
+pub use build_print as inner_log;
 pub use child::{CmdChildren, FunChildren};
 pub use io::{CmdIn, CmdOut};
+#[cfg(not(feature = "build-print"))]
 #[doc(hidden)]
 pub use log as inner_log;
 #[doc(hidden)]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -39,6 +39,9 @@ macro_rules! info {
 macro_rules! debug {
     ($($arg:tt)*) => {{
         $crate::try_init_default_logger();
+        #[cfg(feature = "build-print")]
+        $crate::inner_log::info!($($arg)*);
+        #[cfg(not(feature = "build-print"))]
         $crate::inner_log::debug!($($arg)*);
     }}
 }
@@ -48,6 +51,9 @@ macro_rules! debug {
 macro_rules! trace {
     ($($arg:tt)*) => {{
         $crate::try_init_default_logger();
+        #[cfg(feature = "build-print")]
+        $crate::inner_log::info!($($arg)*);
+        #[cfg(not(feature = "build-print"))]
         $crate::inner_log::trace!($($arg)*);
     }}
 }


### PR DESCRIPTION
This PR introduces a new optional `build-print` feature, allowing users to capture and display logs generated during `build.rs` execution.

### Changes

- Adds `build-print` as an optional dependency, conditionally enabling it via the Cargo feature flag.
    
- Updates logging macros (`debug!`, `trace!`) to route output through `build-print` when the feature is active, ensuring logs appear during build scripts.
    
- Maintains backward compatibility by falling back to standard `log` crate behavior when `build-print` is not enabled.
    

### Usage

Enable the feature in your `Cargo.toml`:

```toml
[dependencies.rust_cmd_lib]
features = ["build-print"]
```

This is particularly useful for debugging build-time logic or tracking output from custom `build.rs` workflows.