### PR TITLE
Fix test_escape() to work with any path to echo(1)

### DIFF
--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -217,7 +217,7 @@ fn test_export_cmd() {
 fn test_escape() {
     let xxx = 42;
     assert_eq!(
-        run_fun!(/bin/echo "\"a你好${xxx}世界b\"").unwrap(),
+        run_fun!(echo "\"a你好${xxx}世界b\"").unwrap(),
         "\"a你好42世界b\""
     );
 }


### PR DESCRIPTION
on some Linux distros like NixOS, echo is not /bin/echo, but somewhere else. this patch removes the absolute path in test_escape(), so we can find echo anywhere in PATH.