### PR TITLE
Inherit tracing spans, if the program uses tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,15 @@ log = "0.4.20"
 faccess = "0.2.4"
 os_pipe = "1.1.4"
 env_logger = "0.10.0"
+tracing = { version = "0.1.41", optional = true }
 
 [dev-dependencies]
 rayon = "1.8.0"
 clap = { version = "4", features = ["derive"] }
 byte-unit = "4.0.19"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+
+[[example]]
+name = "tracing"
+required-features = ["tracing"]

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -1,0 +1,27 @@
+use cmd_lib::{run_cmd, CmdResult};
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
+
+#[cmd_lib::main]
+fn main() -> CmdResult {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .with(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    copy_thing()?;
+
+    Ok(())
+}
+
+#[tracing::instrument]
+fn copy_thing() -> CmdResult {
+    // Log output from stderr inherits the `copy_thing` span from this function
+    run_cmd!(dd if=/dev/urandom of=/dev/null bs=1M count=1000)?;
+
+    Ok(())
+}

--- a/src/child.rs
+++ b/src/child.rs
@@ -341,8 +341,12 @@ struct StderrThread {
 
 impl StderrThread {
     fn new(cmd: &str, file: &str, line: u32, stderr: Option<PipeReader>, capture: bool) -> Self {
+        #[cfg(feature = "tracing")]
+        let span = tracing::Span::current();
         if let Some(stderr) = stderr {
             let thread = std::thread::spawn(move || {
+                #[cfg(feature = "tracing")]
+                let _entered = span.enter();
                 let mut output = String::new();
                 BufReader::new(stderr)
                     .lines()


### PR DESCRIPTION
some programs use [tracing](https://docs.rs/tracing/0.1.41/tracing/), a [log](https://docs.rs/log/0.4.27/log/)-compatible logging framework. tracing allows programs to prefix log messages with additional context via [span!()](https://docs.rs/tracing/0.1.41/tracing/macro.span.html) or [#[instrument]](https://docs.rs/tracing/0.1.41/tracing/attr.instrument.html), but StderrThread spawns a new thread to read command output, so this context is lost.

this patch adds an optional feature “tracing” with an optional dependency on tracing. when enabled, StderrThread::new() propagates the current span (if any) from the calling thread to the new thread. as a result, any context added by the calling thread is preserved in the info logs generated by stderr.