### PR TITLE
Minor cleanups

### DIFF
--- a/examples/dd_test.rs
+++ b/examples/dd_test.rs
@@ -15,10 +15,10 @@
 //! [INFO ] Total bandwidth: 1.11 GiB/s
 //! ```
 use byte_unit::Byte;
+use clap::Parser;
 use cmd_lib::*;
 use rayon::prelude::*;
 use std::time::Instant;
-use clap::Parser;
 
 const DATA_SIZE: u64 = 10 * 1024 * 1024 * 1024; // 10GB data
 


### PR DESCRIPTION
this patch removes an unnecessary use of Option in Cmds by calling take() on the whole Vec, instead of on each Cmd.

since this repo appears to be formatted with `cargo fmt --all` with the exception of a single import in examples/dd_test.rs, this patch also formats that import and creates rustfmt.toml as a hint that auto-formatting is ok. that way, i can work on this locally and make commits without having to undo this import change over and over.