### PR TITLE
Fix handling of `ignore` in wait() and wait_with_all()

### DIFF
--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -248,15 +248,29 @@ fn test_ignore_and_pipefail() {
         //     .wait_with_pipe(&mut |_stdout| {})),
     ];
 
+    macro_rules! check_eq {
+        ($left:expr, $right:expr, $($rest:tt)+) => {{
+            let left = $left;
+            let right = $right;
+            if left != right {
+                eprintln!("assertion failed ({} != {}): {}", left, right, format!($($rest)+));
+                false
+            } else {
+                true
+            }
+        }};
+    }
+
+    let mut ok = true;
     for case in test_cases.iter().flat_map(|items| items.iter()) {
-        assert_eq!(
+        ok &= check_eq!(
             (case.code)(),
             case.expected_ok_pipefail_on,
             "{} when pipefail is on",
             case.code_str
         );
         set_pipefail(false);
-        assert_eq!(
+        ok &= check_eq!(
             (case.code)(),
             case.expected_ok_pipefail_off,
             "{} when pipefail is off",
@@ -264,6 +278,8 @@ fn test_ignore_and_pipefail() {
         );
         set_pipefail(true);
     }
+
+    assert!(ok);
 }
 
 #[test]

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -150,14 +150,6 @@ fn test_pipe() {
 
     let wc_cmd = "wc";
     assert!(run_cmd!(ls | $wc_cmd).is_ok());
-
-    // test pipefail
-    assert!(run_cmd!(false | true).is_err());
-    assert!(run_fun!(false | true).is_err());
-    assert!(run_fun!(ignore false | true).is_ok());
-    set_pipefail(false);
-    assert!(run_fun!(false | true).is_ok());
-    set_pipefail(true);
 }
 
 #[test]

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -150,10 +150,9 @@ fn test_pipe() {
 
     let wc_cmd = "wc";
     assert!(run_cmd!(ls | $wc_cmd).is_ok());
-}
 
-#[test]
-fn test_ignore_and_pipefail() {
+    // test `ignore` command and pipefail mode
+    // FIXME: make set_pipefail() thread safe, then move this to a separate test_ignore_and_pipefail()
     struct TestCase {
         /// Run the test case, returning whether the result `.is_ok()`.
         code: fn() -> bool,


### PR DESCRIPTION
the logic in CmdChildren and FunChildren is currently a bit organic and inconsistent. as a result, the following test cases (also added in this patch) return the wrong results:

```
assertion failed (false != true): spawn!(ignore false).unwrap().wait().is_ok() when pipefail is on
assertion failed (false != true): spawn!(ignore false).unwrap().wait().is_ok() when pipefail is off
assertion failed (false != true): spawn!(ignore true | false).unwrap().wait().is_ok() when pipefail is on
assertion failed (false != true): spawn!(ignore true | false).unwrap().wait().is_ok() when pipefail is off
assertion failed (false != true): spawn!(ignore false | true).unwrap().wait().is_ok() when pipefail is on
assertion failed (false != true): spawn!(ignore false | false).unwrap().wait().is_ok() when pipefail is on
assertion failed (false != true): spawn!(ignore false | false).unwrap().wait().is_ok() when pipefail is off
assertion failed (false != true): spawn_with_output!(ignore false).unwrap().wait_with_all().0.is_ok() when pipefail is on
assertion failed (false != true): spawn_with_output!(ignore false).unwrap().wait_with_all().0.is_ok() when pipefail is off
assertion failed (false != true): spawn_with_output!(ignore true | false).unwrap().wait_with_all().0.is_ok() when pipefail is on
assertion failed (false != true): spawn_with_output!(ignore true | false).unwrap().wait_with_all().0.is_ok() when pipefail is off
assertion failed (false != true): spawn_with_output!(ignore false | false).unwrap().wait_with_all().0.is_ok() when pipefail is on
assertion failed (false != true): spawn_with_output!(ignore false | false).unwrap().wait_with_all().0.is_ok() when pipefail is off
```

this patch fixes wait() and wait_with_all() to correctly handle `ignore`. it also adds a comprehensive test suite that verifies that all of the ways you can get a CmdResult or FunResult (“entry points”) correctly handle the `ignore` command and pipefail mode. note that:

- wait_with_pipe() suffers from an unrelated and more complicated bug, so it’s not yet included in the test suite
- set_pipefail() is not thread safe, so the new tests have to live in test_pipe() for now, otherwise both will often fail