### PR TITLE
Fix wait_with_pipe() so it waits for last child and uses exit status

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -460,7 +460,7 @@ impl Cmd {
             if pipe_out || with_output {
                 let handle = thread::Builder::new().spawn(move || internal_cmd(&mut env))?;
                 Ok(CmdChild::new(
-                    CmdChildHandle::Thread(handle),
+                    CmdChildHandle::Thread(Some(handle)),
                     full_cmds,
                     self.file,
                     self.line,

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -290,42 +290,42 @@ fn test_pipe() -> CmdResult {
         .wait_with_pipe(&mut |_stdout| {})
         .is_ok());
 
-    // wait_with_pipe_thread() checks the exit status of the last child, even if pipefail is disabled
+    // wait_with_borrowed_pipe() checks the exit status of the last child, even if pipefail is disabled
     set_pipefail(false);
     assert!(spawn_with_output!(true | false)?
-        .wait_with_pipe_thread(|_stdout| {})
+        .wait_with_borrowed_pipe(&mut |_stdout| {})
         .is_err());
     assert!(spawn_with_output!(true | true)?
-        .wait_with_pipe_thread(|_stdout| {})
+        .wait_with_borrowed_pipe(&mut |_stdout| {})
         .is_ok());
     assert!(spawn_with_output!(false)?
-        .wait_with_pipe_thread(|_stdout| {})
+        .wait_with_borrowed_pipe(&mut |_stdout| {})
         .is_err());
     assert!(spawn_with_output!(true)?
-        .wait_with_pipe_thread(|_stdout| {})
+        .wait_with_borrowed_pipe(&mut |_stdout| {})
         .is_ok());
     set_pipefail(true);
-    // wait_with_pipe_thread() checks the exit status of the other children, unless pipefail is disabled
+    // wait_with_borrowed_pipe() checks the exit status of the other children, unless pipefail is disabled
     set_pipefail(false);
     assert!(spawn_with_output!(false | true)?
-        .wait_with_pipe_thread(|_stdout| {})
+        .wait_with_borrowed_pipe(&mut |_stdout| {})
         .is_ok());
     set_pipefail(true);
     assert!(spawn_with_output!(false | true)?
-        .wait_with_pipe_thread(|_stdout| {})
+        .wait_with_borrowed_pipe(&mut |_stdout| {})
         .is_err());
     assert!(spawn_with_output!(true | true)?
-        .wait_with_pipe_thread(|_stdout| {})
+        .wait_with_borrowed_pipe(&mut |_stdout| {})
         .is_ok());
-    // wait_with_pipe_thread() handles `ignore`
+    // wait_with_borrowed_pipe() handles `ignore`
     assert!(spawn_with_output!(ignore false | true)?
-        .wait_with_pipe_thread(|_stdout| {})
+        .wait_with_borrowed_pipe(&mut |_stdout| {})
         .is_ok());
     assert!(spawn_with_output!(ignore true | false)?
-        .wait_with_pipe_thread(|_stdout| {})
+        .wait_with_borrowed_pipe(&mut |_stdout| {})
         .is_ok());
     assert!(spawn_with_output!(ignore false)?
-        .wait_with_pipe_thread(|_stdout| {})
+        .wait_with_borrowed_pipe(&mut |_stdout| {})
         .is_ok());
 
     Ok(())

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -134,7 +134,7 @@ fn test_tls_set() {
 }
 
 #[test]
-fn test_pipe() -> CmdResult {
+fn test_pipe() {
     assert!(run_cmd!(echo "xx").is_ok());
     assert_eq!(run_fun!(echo "xx").unwrap(), "xx");
     assert!(run_cmd!(echo xx | wc).is_ok());
@@ -246,7 +246,7 @@ fn test_pipe() -> CmdResult {
             .wait_with_raw_output(&mut vec![])),
         test_cases_for_entry_point!((spawn_with_output!(...))
             .unwrap()
-            .wait_with_borrowed_pipe(&mut |_stdout| {})),
+            .wait_with_pipe(&mut |_stdout| {})),
     ];
 
     macro_rules! check_eq {
@@ -281,64 +281,6 @@ fn test_pipe() -> CmdResult {
     }
 
     assert!(ok);
-
-    // test that illustrates the bugs in wait_with_pipe()
-    // FIXME: make set_pipefail() thread safe, then move this to a separate test function
-    assert!(spawn_with_output!(false)?.wait_with_all().0.is_err());
-    assert!(spawn_with_output!(false)?.wait_with_output().is_err());
-    assert!(spawn_with_output!(false)?
-        .wait_with_raw_output(&mut vec![])
-        .is_err());
-
-    // wait_with_pipe() can’t check the exit status of the last child
-    assert!(spawn_with_output!(false)?
-        .wait_with_pipe(&mut |_stdout| {})
-        .is_ok());
-
-    // wait_with_pipe() kills the last child when the provided function returns
-    assert!(spawn_with_output!(sh -c "while :; do :; done")?
-        .wait_with_pipe(&mut |_stdout| {})
-        .is_ok());
-
-    // wait_with_borrowed_pipe() checks the exit status of the last child, even if pipefail is disabled
-    set_pipefail(false);
-    assert!(spawn_with_output!(true | false)?
-        .wait_with_borrowed_pipe(&mut |_stdout| {})
-        .is_err());
-    assert!(spawn_with_output!(true | true)?
-        .wait_with_borrowed_pipe(&mut |_stdout| {})
-        .is_ok());
-    assert!(spawn_with_output!(false)?
-        .wait_with_borrowed_pipe(&mut |_stdout| {})
-        .is_err());
-    assert!(spawn_with_output!(true)?
-        .wait_with_borrowed_pipe(&mut |_stdout| {})
-        .is_ok());
-    set_pipefail(true);
-    // wait_with_borrowed_pipe() checks the exit status of the other children, unless pipefail is disabled
-    set_pipefail(false);
-    assert!(spawn_with_output!(false | true)?
-        .wait_with_borrowed_pipe(&mut |_stdout| {})
-        .is_ok());
-    set_pipefail(true);
-    assert!(spawn_with_output!(false | true)?
-        .wait_with_borrowed_pipe(&mut |_stdout| {})
-        .is_err());
-    assert!(spawn_with_output!(true | true)?
-        .wait_with_borrowed_pipe(&mut |_stdout| {})
-        .is_ok());
-    // wait_with_borrowed_pipe() handles `ignore`
-    assert!(spawn_with_output!(ignore false | true)?
-        .wait_with_borrowed_pipe(&mut |_stdout| {})
-        .is_ok());
-    assert!(spawn_with_output!(ignore true | false)?
-        .wait_with_borrowed_pipe(&mut |_stdout| {})
-        .is_ok());
-    assert!(spawn_with_output!(ignore false)?
-        .wait_with_borrowed_pipe(&mut |_stdout| {})
-        .is_ok());
-
-    Ok(())
 }
 
 #[test]

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -217,6 +217,17 @@ fn test_pipe() -> CmdResult {
                 test_case!(true, true, ($macro $bang (ignore true | false)) $($after)*),
                 test_case!(true, true, ($macro $bang (ignore false | true)) $($after)*),
                 test_case!(true, true, ($macro $bang (ignore false | false)) $($after)*),
+                // Built-ins should work too, without locking up.
+                test_case!(true, true, ($macro $bang (echo)) $($after)*),
+                test_case!(true, true, ($macro $bang (echo | true)) $($after)*),
+                test_case!(false, false, ($macro $bang (echo | false)) $($after)*),
+                test_case!(true, true, ($macro $bang (true | echo)) $($after)*),
+                test_case!(false, true, ($macro $bang (false | echo)) $($after)*),
+                test_case!(true, true, ($macro $bang (cd /)) $($after)*),
+                test_case!(true, true, ($macro $bang (cd / | true)) $($after)*),
+                test_case!(false, false, ($macro $bang (cd / | false)) $($after)*),
+                test_case!(true, true, ($macro $bang (true | cd /)) $($after)*),
+                test_case!(false, true, ($macro $bang (false | cd /)) $($after)*),
             ]
         };
     }

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -233,10 +233,9 @@ fn test_pipe() -> CmdResult {
         test_cases_for_entry_point!((spawn_with_output!(...))
             .unwrap()
             .wait_with_raw_output(&mut vec![])),
-        // FIXME: wait_with_pipe() is currently busted
-        // test_cases_for_entry_point!((spawn_with_output!(...))
-        //     .unwrap()
-        //     .wait_with_pipe(&mut |_stdout| {})),
+        test_cases_for_entry_point!((spawn_with_output!(...))
+            .unwrap()
+            .wait_with_borrowed_pipe(&mut |_stdout| {})),
     ];
 
     macro_rules! check_eq {


### PR DESCRIPTION
unlike all of the other wait methods in FunChildren and CmdChildren, wait_with_pipe() does not actually wait for the last child in the pipeline to exit. it kills the last child when the provided function returns, and ignores that child’s exit status. killing the last child is potentially useful, to avoid deadlock if the caller fails to fully read stdout, but ignoring the last child’s exit status seems like a bug.

this patch fixes that bug by making wait_with_pipe() wait for the last child and use its exit status. if the child can’t exit because it has unread output, we automatically read and discard that output and wait again, until the child exits.

this is a breaking change for two reasons:
- `f` now takes a `&mut Box<dyn Read>`, not a `Box<dyn Read>` — though depending on the code provided in `f`, this may only result in a new `#[warn(unused_mut)]` warning
- commands like `yes` or `sh -c "yes >&2 &"` now indefinitely block the return of wait_with_pipe() — though this is consistent with the behaviour of all the other wait methods