### PR TITLE
Add non-global ways to set debug and pipefail modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,9 @@ That said, there are some limitations to be aware of:
   each thread will have its own independent version of the variable
 - [`set_debug`](https://docs.rs/cmd_lib/latest/cmd_lib/fn.set_debug.html) and
   [`set_pipefail`](https://docs.rs/cmd_lib/latest/cmd_lib/fn.set_pipefail.html) are *global* and affect all threads;
-  there is currently no way to change those settings without affecting other threads
+  to change those settings without affecting other threads, use
+  [`ScopedDebug`](https://docs.rs/cmd_lib/latest/cmd_lib/struct.ScopedDebug.html) and
+  [`ScopedPipefail`](https://docs.rs/cmd_lib/latest/cmd_lib/struct.ScopedPipefail.html)
 
 [std::env::set_var]: https://doc.rust-lang.org/std/env/fn.set_var.html
 [std::env::remove_var]: https://doc.rust-lang.org/std/env/fn.remove_var.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,7 +394,7 @@ pub use log as inner_log;
 pub use logger::try_init_default_logger;
 #[doc(hidden)]
 pub use process::{register_cmd, AsOsStr, Cmd, CmdString, Cmds, GroupCmds, Redirect};
-pub use process::{set_debug, set_pipefail, CmdEnv};
+pub use process::{set_debug, set_pipefail, CmdEnv, ScopedDebug, ScopedPipefail};
 
 mod builtins;
 mod child;

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -145,15 +145,16 @@ fn test_pipe() {
     assert!(run_cmd!(false | wc).is_err());
     assert!(run_cmd!(echo xx | false | wc | wc | wc).is_err());
 
-    set_pipefail(false);
+    let _pipefail = ScopedPipefail::set(false);
     assert!(run_cmd!(du -ah . | sort -hr | head -n 10).is_ok());
-    set_pipefail(true);
+    let _pipefail = ScopedPipefail::set(true);
 
     let wc_cmd = "wc";
     assert!(run_cmd!(ls | $wc_cmd).is_ok());
+}
 
-    // test `ignore` command and pipefail mode
-    // FIXME: make set_pipefail() thread safe, then move this to a separate test_ignore_and_pipefail()
+#[test]
+fn test_ignore_and_pipefail() {
     struct TestCase {
         /// Run the test case, returning whether the result `.is_ok()`.
         code: fn() -> bool,
@@ -261,14 +262,14 @@ fn test_pipe() {
             "{} when pipefail is on",
             case.code_str
         );
-        set_pipefail(false);
+        let _pipefail = ScopedPipefail::set(false);
         ok &= check_eq!(
             (case.code)(),
             case.expected_ok_pipefail_off,
             "{} when pipefail is off",
             case.code_str
         );
-        set_pipefail(true);
+        let _pipefail = ScopedPipefail::set(true);
     }
 
     assert!(ok);

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -108,6 +108,7 @@ fn test_vars_in_str3() {
 }
 
 #[test]
+// FIXME: doctests have no effect here, and we need to split these into one test per error
 /// ```compile_fail
 /// run_cmd!(echo "${msg0}").unwrap();
 /// assert_eq!(run_fun!(echo "${ msg }").unwrap(), "${ msg }");
@@ -274,6 +275,7 @@ fn test_pipe() {
 }
 
 #[test]
+// FIXME: doctests have no effect here, and we need to split these into one test per error
 /// ```compile_fail
 /// run_cmd!(ls > >&1).unwrap();
 /// run_cmd!(ls >>&1).unwrap();
@@ -345,6 +347,7 @@ fn test_current_dir() {
 }
 
 #[test]
+// FIXME: doctests have no effect here, and we need to split these into one test per error
 /// ```compile_fail
 /// run_cmd!(ls / /x &>>> /tmp/f).unwrap();
 /// run_cmd!(ls / /x &> > /tmp/f).unwrap();


### PR DESCRIPTION
this is the second of two patches aimed at addressing thread safety issues. set_debug() and set_pipefail() change the debug and pipefail settings globally, which makes it impossible to reliably run commands with different settings in different threads. in single-threaded programs, this doesn’t really matter, so they are certainly still useful.

this patch adds ScopedDebug and ScopedPipefail, which override the global debug and pipefail settings, in the current thread only, until they go out of scope. calling `set(new_value)` changes the setting to `Some(new_value)`, giving you a `Self(old_value)` that when dropped, restores the value to `old_value`.

i’ve also split the ignore and pipefail tests into their own test function test_ignore_and_pipefail(), using ScopedPipefail so they can run in parallel with the other tests in test_pipe().